### PR TITLE
Fix date formatting for new events

### DIFF
--- a/src/api/eventApi.js
+++ b/src/api/eventApi.js
@@ -57,21 +57,22 @@ export default {
   },
 
   createEvent(event) {
-    // For JSON payloads (POST/PUT), Spring Boot's Jackson deserializer is often flexible
-    // with date strings for LocalDate fields in DTOs.
-    // If event.eventDate is a JavaScript Date object, it will likely be serialized to an
-    // ISO 8601 string (e.g., "2025-05-01T00:00:00.000Z"). Spring can usually parse this
-    // into a LocalDate (extracting the date part).
-    // If event.eventDate is already a "yyyy-MM-dd" string, that's also typically fine.
-    // Explicit formatting here (e.g., eventDate: formatDateToYYYYMMDD(event.eventDate))
-    // might be needed if you encounter issues or if your backend DTO has strict @DateTimeFormat.
-    return apiClient.post('/events', event)
+    const payload = {
+      ...event,
+      eventDate: formatDateToYYYYMMDD(event.eventDate)
+    };
+
+    return apiClient.post('/events', payload)
       .then(response => response.data);
   },
 
   updateEvent(id, event) {
-    // Similar considerations as createEvent regarding event.eventDate formatting.
-    return apiClient.put(`/events/${id}`, event)
+    const payload = {
+      ...event,
+      eventDate: formatDateToYYYYMMDD(event.eventDate)
+    };
+
+    return apiClient.put(`/events/${id}`, payload)
       .then(response => response.data);
   },
 

--- a/src/components/TrainingCalendar.vue
+++ b/src/components/TrainingCalendar.vue
@@ -353,9 +353,10 @@ function handleEventClick(info) {
 // Handle clicking on a date
 function handleDateClick(info) {
   if (!isAdmin.value) return;
-  
+
   isEditMode.value = false;
-  selectedDate.value = info.dateStr;
+  const dateOnly = info.dateStr.split('T')[0];
+  selectedDate.value = dateOnly;
   
   // Get time information if available
   let startTime = '09:00';
@@ -371,25 +372,25 @@ function handleDateClick(info) {
     const endTime = `${endHour.toString().padStart(2, '0')}:${minutes}`;
     
     Object.assign(eventForm, {
-      id: '', 
-      category: 'CONSULTANTA', 
+      id: '',
+      category: 'CONSULTANTA',
       location: '',
-      maxParticipants: 10, 
-      description: '', 
-      participants: [], 
-      date: info.dateStr,
+      maxParticipants: 10,
+      description: '',
+      participants: [],
+      date: dateOnly,
       startTime,
       endTime
     });
   } else {
     Object.assign(eventForm, {
-      id: '', 
-      category: 'CONSULTANTA', 
+      id: '',
+      category: 'CONSULTANTA',
       location: '',
-      maxParticipants: 10, 
-      description: '', 
-      participants: [], 
-      date: info.dateStr,
+      maxParticipants: 10,
+      description: '',
+      participants: [],
+      date: dateOnly,
       startTime: '09:00',
       endTime: '17:00'
     });
@@ -401,7 +402,9 @@ function handleDateClick(info) {
 // Prepare edit event
 function prepareEditEvent(eventData, info) {
   isEditMode.value = true;
-  
+
+  const dateOnly = eventData.start.split('T')[0];
+
   Object.assign(eventForm, {
     id: eventData.id,
     category: eventData.extendedProps.category,
@@ -409,7 +412,7 @@ function prepareEditEvent(eventData, info) {
     maxParticipants: eventData.extendedProps.maxParticipants,
     description: eventData.extendedProps.description,
     participants: eventData.extendedProps.participants,
-    date: eventData.start,
+    date: dateOnly,
     startTime: eventData.extendedProps.startTime,
     endTime: eventData.extendedProps.endTime
   });

--- a/src/store/eventStore.js
+++ b/src/store/eventStore.js
@@ -80,7 +80,7 @@ const eventStore = reactive({
     try {
       // Ensure data is in the format expected by the backend
       const eventRequest = {
-        eventDate: eventData.eventDate || eventData.date,
+        eventDate: (eventData.eventDate || eventData.date)?.split('T')[0],
         startTime: eventData.startTime || '09:00',
         endTime: eventData.endTime || '17:00',
         categoryId: eventData.categoryId || eventData.category,
@@ -115,7 +115,7 @@ const eventStore = reactive({
     try {
       // Ensure data is in the format expected by the backend
       const eventRequest = {
-        eventDate: eventData.eventDate || eventData.date,
+        eventDate: (eventData.eventDate || eventData.date)?.split('T')[0],
         startTime: eventData.startTime || '09:00',
         endTime: eventData.endTime || '17:00',
         categoryId: eventData.categoryId || eventData.category,


### PR DESCRIPTION
## Summary
- ensure new events send a plain `yyyy-MM-dd` date
- normalize date values when clicking calendar or editing events

## Testing
- `npm test` *(fails: Missing script)*
- `./mvnw test` *(fails: could not fetch Maven due to network restrictions)*