### PR TITLE
Add basic JWT auth

### DIFF
--- a/calendar-api/pom.xml
+++ b/calendar-api/pom.xml
@@ -68,12 +68,29 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-	</dependencies>
+                <dependency>
+                        <groupId>org.springframework.security</groupId>
+                        <artifactId>spring-security-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-api</artifactId>
+                        <version>0.12.3</version>
+                </dependency>
+                <dependency>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-impl</artifactId>
+                        <version>0.12.3</version>
+                        <scope>runtime</scope>
+                </dependency>
+                <dependency>
+                        <groupId>io.jsonwebtoken</groupId>
+                        <artifactId>jjwt-jackson</artifactId>
+                        <version>0.12.3</version>
+                        <scope>runtime</scope>
+                </dependency>
+        </dependencies>
 
 	<build>
 		<plugins>

--- a/calendar-api/src/main/java/com/training/calendar/config/SecurityConfig.java
+++ b/calendar-api/src/main/java/com/training/calendar/config/SecurityConfig.java
@@ -1,11 +1,20 @@
 package com.training.calendar.config;
 
+import com.training.calendar.security.JwtAuthenticationFilter;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -15,19 +24,24 @@ import java.util.List;
 
 @Configuration
 @EnableWebSecurity
+@org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 public class SecurityConfig {
+
+    @Autowired
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-                .csrf(AbstractHttpConfigurer::disable)  // Disable CSRF - consider enabling in production with proper configuration
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/api/**").permitAll()  // Public API endpoints
-                        // Add restrictions as needed for admin endpoints
-                        // .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/events/**").permitAll()
                         .anyRequest().authenticated()
-                );
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
@@ -44,5 +58,15 @@ public class SecurityConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/api/**", configuration);
         return source;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
     }
 }

--- a/calendar-api/src/main/java/com/training/calendar/controller/AuthController.java
+++ b/calendar-api/src/main/java/com/training/calendar/controller/AuthController.java
@@ -1,0 +1,41 @@
+package com.training.calendar.controller;
+
+import com.training.calendar.dto.request.LoginRequest;
+import com.training.calendar.dto.request.RegisterRequest;
+import com.training.calendar.dto.response.AuthResponse;
+import com.training.calendar.security.JwtTokenProvider;
+import com.training.calendar.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthenticationManager authenticationManager;
+    private final UserService userService;
+    private final JwtTokenProvider tokenProvider;
+
+    @PostMapping("/register")
+    public ResponseEntity<AuthResponse> register(@Valid @RequestBody RegisterRequest request) {
+        userService.registerUser(request.getEmail(), request.getPassword());
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword()));
+        String token = tokenProvider.generateToken(authentication.getName());
+        return ResponseEntity.ok(new AuthResponse(token));
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword()));
+        String token = tokenProvider.generateToken(authentication.getName());
+        return ResponseEntity.ok(new AuthResponse(token));
+    }
+}

--- a/calendar-api/src/main/java/com/training/calendar/controller/EventController.java
+++ b/calendar-api/src/main/java/com/training/calendar/controller/EventController.java
@@ -10,6 +10,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.security.access.prepost.PreAuthorize;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -74,6 +75,7 @@ public class EventController {
 
 
     @PostMapping
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<EventResponse> createEvent(@Valid @RequestBody EventRequest eventRequest) {
         try {
             EventResponse createdEvent = eventService.createEvent(eventRequest);
@@ -87,6 +89,7 @@ public class EventController {
     }
 
     @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<EventResponse> updateEvent(
             @PathVariable String id,
             @Valid @RequestBody EventRequest eventRequest) {
@@ -100,6 +103,7 @@ public class EventController {
     }
 
     @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<Void> deleteEvent(@PathVariable String id) {
         eventService.deleteEvent(id);
         return ResponseEntity.noContent().build();

--- a/calendar-api/src/main/java/com/training/calendar/dto/request/LoginRequest.java
+++ b/calendar-api/src/main/java/com/training/calendar/dto/request/LoginRequest.java
@@ -1,0 +1,14 @@
+package com.training.calendar.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class LoginRequest {
+    @NotBlank
+    @Email
+    private String email;
+    @NotBlank
+    private String password;
+}

--- a/calendar-api/src/main/java/com/training/calendar/dto/request/RegisterRequest.java
+++ b/calendar-api/src/main/java/com/training/calendar/dto/request/RegisterRequest.java
@@ -1,0 +1,14 @@
+package com.training.calendar.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class RegisterRequest {
+    @NotBlank
+    @Email
+    private String email;
+    @NotBlank
+    private String password;
+}

--- a/calendar-api/src/main/java/com/training/calendar/dto/response/AuthResponse.java
+++ b/calendar-api/src/main/java/com/training/calendar/dto/response/AuthResponse.java
@@ -1,0 +1,10 @@
+package com.training.calendar.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class AuthResponse {
+    private String token;
+}

--- a/calendar-api/src/main/java/com/training/calendar/model/Role.java
+++ b/calendar-api/src/main/java/com/training/calendar/model/Role.java
@@ -1,0 +1,22 @@
+package com.training.calendar.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "roles")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Role {
+    @Id
+    private String id;
+
+    private String name;
+}

--- a/calendar-api/src/main/java/com/training/calendar/model/User.java
+++ b/calendar-api/src/main/java/com/training/calendar/model/User.java
@@ -1,0 +1,37 @@
+package com.training.calendar.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Entity
+@Table(name = "users")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+    @Id
+    private String id;
+
+    @Column(unique = true)
+    private String email;
+
+    private String password;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    private List<UserRole> roles = new ArrayList<>();
+
+    @PrePersist
+    public void onPrePersist() {
+        if (id == null) {
+            id = UUID.randomUUID().toString();
+        }
+    }
+}

--- a/calendar-api/src/main/java/com/training/calendar/model/UserRole.java
+++ b/calendar-api/src/main/java/com/training/calendar/model/UserRole.java
@@ -1,0 +1,35 @@
+package com.training.calendar.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "user_roles")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserRole {
+    @Id
+    private String id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "role_id")
+    private Role role;
+
+    @PrePersist
+    public void onPrePersist() {
+        if (id == null) {
+            id = UUID.randomUUID().toString();
+        }
+    }
+}

--- a/calendar-api/src/main/java/com/training/calendar/repository/RoleRepository.java
+++ b/calendar-api/src/main/java/com/training/calendar/repository/RoleRepository.java
@@ -1,0 +1,10 @@
+package com.training.calendar.repository;
+
+import com.training.calendar.model.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RoleRepository extends JpaRepository<Role, String> {
+    Optional<Role> findByName(String name);
+}

--- a/calendar-api/src/main/java/com/training/calendar/repository/UserRepository.java
+++ b/calendar-api/src/main/java/com/training/calendar/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.training.calendar.repository;
+
+import com.training.calendar.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, String> {
+    Optional<User> findByEmail(String email);
+}

--- a/calendar-api/src/main/java/com/training/calendar/repository/UserRoleRepository.java
+++ b/calendar-api/src/main/java/com/training/calendar/repository/UserRoleRepository.java
@@ -1,0 +1,7 @@
+package com.training.calendar.repository;
+
+import com.training.calendar.model.UserRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRoleRepository extends JpaRepository<UserRole, String> {
+}

--- a/calendar-api/src/main/java/com/training/calendar/security/JwtAuthenticationFilter.java
+++ b/calendar-api/src/main/java/com/training/calendar/security/JwtAuthenticationFilter.java
@@ -1,0 +1,49 @@
+package com.training.calendar.security;
+
+import com.training.calendar.service.UserService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider tokenProvider;
+    private final UserService userService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String header = request.getHeader("Authorization");
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+            if (tokenProvider.validateToken(token)) {
+                String username = tokenProvider.getUsername(token);
+                UserDetails userDetails = userService.loadUserByUsername(username);
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getServletPath();
+        return path.startsWith("/api/auth");
+    }
+}

--- a/calendar-api/src/main/java/com/training/calendar/security/JwtTokenProvider.java
+++ b/calendar-api/src/main/java/com/training/calendar/security/JwtTokenProvider.java
@@ -1,0 +1,54 @@
+package com.training.calendar.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+
+@Component
+public class JwtTokenProvider {
+
+    @Value("${security.jwt.secret:SecretKey123456789012345678901234567890}")
+    private String jwtSecret;
+
+    @Value("${security.jwt.expiration-ms:3600000}")
+    private long jwtExpirationMs;
+
+    private Key getSigningKey() {
+        return Keys.hmacShaKeyFor(jwtSecret.getBytes());
+    }
+
+    public String generateToken(String username) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + jwtExpirationMs);
+        return Jwts.builder()
+                .setSubject(username)
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String getUsername(String token) {
+        Claims claims = Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.getSubject();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(getSigningKey()).build().parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/calendar-api/src/main/java/com/training/calendar/service/UserService.java
+++ b/calendar-api/src/main/java/com/training/calendar/service/UserService.java
@@ -1,0 +1,11 @@
+package com.training.calendar.service;
+
+import com.training.calendar.model.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+import java.util.Optional;
+
+public interface UserService extends UserDetailsService {
+    User registerUser(String email, String password);
+    Optional<User> findByEmail(String email);
+}

--- a/calendar-api/src/main/java/com/training/calendar/service/impl/UserServiceImpl.java
+++ b/calendar-api/src/main/java/com/training/calendar/service/impl/UserServiceImpl.java
@@ -1,0 +1,77 @@
+package com.training.calendar.service.impl;
+
+import com.training.calendar.model.Role;
+import com.training.calendar.model.User;
+import com.training.calendar.model.UserRole;
+import com.training.calendar.repository.RoleRepository;
+import com.training.calendar.repository.UserRepository;
+import com.training.calendar.repository.UserRoleRepository;
+import com.training.calendar.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final RoleRepository roleRepository;
+    private final UserRoleRepository userRoleRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    @Transactional
+    public User registerUser(String email, String password) {
+        if (userRepository.findByEmail(email).isPresent()) {
+            throw new IllegalArgumentException("Email already registered");
+        }
+        Role userRole = roleRepository.findByName("ROLE_USER")
+                .orElseGet(() -> roleRepository.save(Role.builder()
+                        .id("ROLE_USER")
+                        .name("ROLE_USER")
+                        .build()));
+
+        User user = User.builder()
+                .email(email)
+                .password(passwordEncoder.encode(password))
+                .build();
+        userRepository.save(user);
+
+        UserRole ur = UserRole.builder()
+                .user(user)
+                .role(userRole)
+                .build();
+        userRoleRepository.save(ur);
+        user.getRoles().add(ur);
+
+        return user;
+    }
+
+    @Override
+    public Optional<User> findByEmail(String email) {
+        return userRepository.findByEmail(email);
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        List<GrantedAuthority> authorities = user.getRoles().stream()
+                .map(ur -> new SimpleGrantedAuthority(ur.getRole().getName()))
+                .collect(Collectors.toList());
+        return new org.springframework.security.core.userdetails.User(
+                user.getEmail(),
+                user.getPassword(),
+                authorities);
+    }
+}

--- a/calendar-api/src/main/resources/data.sql
+++ b/calendar-api/src/main/resources/data.sql
@@ -1,0 +1,5 @@
+INSERT INTO roles(id, name) VALUES ('ROLE_ADMIN', 'ROLE_ADMIN');
+INSERT INTO roles(id, name) VALUES ('ROLE_USER', 'ROLE_USER');
+
+INSERT INTO users(id, email, password) VALUES ('admin-id', 'admin@example.com', '$2a$10$7EqJtq98hPqEX7fNZaFWoOHi7Ob/uJu3aJJ.Uj4vl4YGTDN8NRr.G');
+INSERT INTO user_roles(id, user_id, role_id) VALUES ('link-1', 'admin-id', 'ROLE_ADMIN');

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,11 +3,17 @@
     <header>
       <h1>Training Calendar System</h1>
     </header>
-    
+
     <main>
-      <TrainingCalendar />
+      <template v-if="token">
+        <TrainingCalendar />
+      </template>
+      <template v-else>
+        <LoginForm @logged-in="onAuth" />
+        <RegisterForm class="mt-4" @registered="onAuth" />
+      </template>
     </main>
-    
+
     <footer>
       <p>Training Calendar System &copy; 2025</p>
     </footer>
@@ -15,7 +21,15 @@
 </template>
 
 <script setup>
+import { ref } from 'vue';
 import TrainingCalendar from './components/TrainingCalendar.vue';
+import LoginForm from './components/LoginForm.vue';
+import RegisterForm from './components/RegisterForm.vue';
+
+const token = ref(localStorage.getItem('jwt'));
+function onAuth() {
+  token.value = localStorage.getItem('jwt');
+}
 </script>
 
 <style>

--- a/src/api/authApi.js
+++ b/src/api/authApi.js
@@ -1,0 +1,12 @@
+import apiClient from './index';
+
+export default {
+  register(email, password) {
+    return apiClient.post('/auth/register', { email, password })
+      .then(res => res.data);
+  },
+  login(email, password) {
+    return apiClient.post('/auth/login', { email, password })
+      .then(res => res.data);
+  }
+};

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -10,6 +10,15 @@ const apiClient = axios.create({
   withCredentials: true // For cookies/credentials if needed
 });
 
+// Attach JWT token if present
+apiClient.interceptors.request.use(config => {
+  const token = localStorage.getItem('jwt');
+  if (token) {
+    config.headers['Authorization'] = `Bearer ${token}`;
+  }
+  return config;
+});
+
 // Add interceptors for handling errors, authentication, etc.
 apiClient.interceptors.response.use(
   response => response,

--- a/src/components/LoginForm.vue
+++ b/src/components/LoginForm.vue
@@ -1,0 +1,31 @@
+<template>
+  <form @submit.prevent="handleSubmit" class="auth-form">
+    <h2>Login</h2>
+    <input v-model="email" type="email" placeholder="Email" required />
+    <input v-model="password" type="password" placeholder="Password" required />
+    <button type="submit">Login</button>
+  </form>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import authApi from '@/api/authApi';
+
+const emit = defineEmits(['logged-in']);
+const email = ref('');
+const password = ref('');
+
+async function handleSubmit() {
+  try {
+    const { token } = await authApi.login(email.value, password.value);
+    localStorage.setItem('jwt', token);
+    emit('logged-in');
+  } catch (e) {
+    console.error('Login failed', e);
+  }
+}
+</script>
+
+<style scoped>
+.auth-form { display: flex; flex-direction: column; gap: 0.5rem; }
+</style>

--- a/src/components/RegisterForm.vue
+++ b/src/components/RegisterForm.vue
@@ -1,0 +1,31 @@
+<template>
+  <form @submit.prevent="handleSubmit" class="auth-form">
+    <h2>Register</h2>
+    <input v-model="email" type="email" placeholder="Email" required />
+    <input v-model="password" type="password" placeholder="Password" required />
+    <button type="submit">Register</button>
+  </form>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import authApi from '@/api/authApi';
+
+const emit = defineEmits(['registered']);
+const email = ref('');
+const password = ref('');
+
+async function handleSubmit() {
+  try {
+    const { token } = await authApi.register(email.value, password.value);
+    localStorage.setItem('jwt', token);
+    emit('registered');
+  } catch (e) {
+    console.error('Registration failed', e);
+  }
+}
+</script>
+
+<style scoped>
+.auth-form { display: flex; flex-direction: column; gap: 0.5rem; }
+</style>


### PR DESCRIPTION
## Summary
- add user, role and user-role entities with repositories
- implement JWT token provider and filter
- secure endpoints using a security config and auth controller
- seed roles and admin user with `data.sql`
- create login and registration forms and store token for API use

## Testing
- `mvn` not available so backend tests were unable to run